### PR TITLE
fix: remove add_child(combat_manager)

### DIFF
--- a/scenes/CombatScene.gd
+++ b/scenes/CombatScene.gd
@@ -54,7 +54,7 @@ func _ready() -> void:
 	player = Player.new()
 	enemy = GoblinScout.new()
 	combat_manager = CombatManager.new(player, enemy)
-	add_child(combat_manager)
+	# CombatManager is purely data-driven (no _process) — no add_child needed
 
 	# Wire signals
 	combat_manager.state_changed.connect(_on_state_changed)


### PR DESCRIPTION
CombatManager doesn't extend Node, so `add_child()` crashes on launch. It has no `_process` and doesn't need to be in the scene tree — removed the call entirely.