### PR TITLE
fix: explicit Card type cast on pop_back()

### DIFF
--- a/src/Deck.gd
+++ b/src/Deck.gd
@@ -28,7 +28,7 @@ func draw(n: int) -> Array[Card]:
 				break
 			_reshuffle_discard()
 		if not draw_pile.is_empty():
-			var card := draw_pile.pop_back()
+			var card: Card = draw_pile.pop_back() as Card
 			hand.append(card)
 			drawn.append(card)
 	return drawn


### PR DESCRIPTION
Godot 4 strict mode infers `pop_back()` as Variant, causing a type error. Added explicit `as Card` cast in `Deck.gd` line 31. Only one occurrence in the codebase.