### PR TITLE
fix: explicit type casts on all Variant-returning calls

### DIFF
--- a/scenes/CombatScene.gd
+++ b/scenes/CombatScene.gd
@@ -189,14 +189,14 @@ func _make_card_panel(card: Card) -> PanelContainer:
 
 	# Type badge
 	var badge := ColorRect.new()
-	badge.color = TYPE_COLORS.get(card.type, Color.WHITE)
+	badge.color = TYPE_COLORS.get(card.type, Color.WHITE) as Color
 	badge.custom_minimum_size = Vector2(0, 24)
 	vbox.add_child(badge)
 
 	var type_lbl := Label.new()
-	type_lbl.text = TYPE_NAMES.get(card.type, "Unknown")
+	type_lbl.text = TYPE_NAMES.get(card.type, "Unknown") as String
 	type_lbl.add_theme_font_size_override("font_size", 11)
-	type_lbl.add_theme_color_override("font_color", TYPE_COLORS.get(card.type, Color.WHITE))
+	type_lbl.add_theme_color_override("font_color", TYPE_COLORS.get(card.type, Color.WHITE) as Color)
 	vbox.add_child(type_lbl)
 
 	# Name

--- a/scenes/RewardScreen.gd
+++ b/scenes/RewardScreen.gd
@@ -44,7 +44,7 @@ func _make_card_panel(card: Card) -> PanelContainer:
 	panel.add_child(vbox)
 
 	# Type badge (colored rectangle)
-	var badge_color := TYPE_COLORS.get(card.type, Color.WHITE)
+	var badge_color: Color = TYPE_COLORS.get(card.type, Color.WHITE) as Color
 	var badge := ColorRect.new()
 	badge.color = badge_color
 	badge.custom_minimum_size = Vector2(0, 30)

--- a/src/map/MapGraph.gd
+++ b/src/map/MapGraph.gd
@@ -38,7 +38,7 @@ func travel_to(node_id: String) -> MapNode:
 func get_current_node() -> MapNode:
 	if current_node_id.is_empty() or not nodes.has(current_node_id):
 		return null
-	return nodes[current_node_id]
+	return nodes[current_node_id] as MapNode
 
 ## Returns true if a BOSS node exists AHEAD of the current position.
 ## The current node itself is excluded — "reachable" means downstream only.

--- a/src/map/RunManager.gd
+++ b/src/map/RunManager.gd
@@ -32,7 +32,7 @@ func get_available_nodes() -> Array[MapNode]:
 	var result: Array[MapNode] = []
 	for conn_id in current.connections:
 		if map.nodes.has(conn_id):
-			result.append(map.nodes[conn_id])
+			result.append(map.nodes[conn_id] as MapNode)
 	return result
 
 ## Advance to the next act — builds a fresh map, resets current position


### PR DESCRIPTION
Full scan of src/ and scenes/ — all Dictionary.get() and Dictionary[] accesses that infer Variant now have explicit `as Type` casts. Files touched: RewardScreen.gd, CombatScene.gd, MapGraph.gd, RunManager.gd.