### PR TITLE
feat: show intent damage values in combat UI

### DIFF
--- a/scenes/CombatScene.gd
+++ b/scenes/CombatScene.gd
@@ -139,7 +139,7 @@ func _refresh_enemy_display() -> void:
 	enemy_hp_bar.value = enemy.hp
 	enemy_hp_label.text = "%d / %d" % [enemy.hp, enemy.max_hp]
 	enemy_block_label.text = "Block: %d" % enemy.block
-	enemy_intent_label.text = "Intent: %s" % _intent_label(enemy.intent)
+	enemy_intent_label.text = "Intent: %s" % _intent_label(enemy)
 	enemy_defeated_overlay.visible = not enemy.is_alive
 
 func _refresh_player_display() -> void:
@@ -226,11 +226,13 @@ func _make_card_panel(card: Card) -> PanelContainer:
 
 	return panel
 
-func _intent_label(intent: Enemy.Intent) -> String:
-	match intent:
-		Enemy.Intent.ATTACK: return "Attack"
-		Enemy.Intent.DEFEND: return "Defend"
-		Enemy.Intent.BUFF:   return "Buff"
+func _intent_label(p_enemy: Enemy) -> String:
+	var val := p_enemy.intent_value
+	match p_enemy.intent:
+		Enemy.Intent.ATTACK: return "Attack (%d)" % val if val > 0 else "Attack"
+		Enemy.Intent.DEFEND: return "Defend (%d)" % val if val > 0 else "Defend"
+		Enemy.Intent.DEBUFF: return "Debuff (%d)" % val if val > 0 else "Debuff"
+		Enemy.Intent.BUFF:   return "Buff (%d)" % val if val > 0 else "Buff"
 		_: return "Unknown"
 
 func _set_reward_visible(visible_flag: bool) -> void:

--- a/src/Enemy.gd
+++ b/src/Enemy.gd
@@ -14,6 +14,7 @@ var hp: int = 10
 var max_hp: int = 10
 var block: int = 0
 var intent: Intent = Intent.ATTACK
+var intent_value: int = 0  # damage/heal amount associated with current intent
 var status_effects: Array[StatusEffect] = []
 var is_alive: bool:
 	get: return hp > 0

--- a/src/enemies/GiantRat.gd
+++ b/src/enemies/GiantRat.gd
@@ -8,9 +8,11 @@ const DAMAGE_PER_HIT: int = 5
 func _init() -> void:
 	super._init("Giant Rat", 30)
 	intent = Intent.ATTACK
+	intent_value = HITS * DAMAGE_PER_HIT
 
 func decide_intent() -> void:
 	intent = Intent.ATTACK
+	intent_value = HITS * DAMAGE_PER_HIT  # 2x5 = 10 total
 
 ## Bites twice — each hit is a separate damage instance (block applies per hit? No — block
 ## absorbs across the full turn; we resolve both hits sequentially so block applies first then HP)

--- a/src/enemies/GoblinScout.gd
+++ b/src/enemies/GoblinScout.gd
@@ -7,9 +7,11 @@ const BASE_ATTACK: int = 8
 func _init() -> void:
 	super._init("Goblin Scout", 20)
 	intent = Intent.ATTACK
+	intent_value = BASE_ATTACK
 
 func decide_intent() -> void:
 	intent = Intent.ATTACK
+	intent_value = BASE_ATTACK
 
 func execute_action(player: Player) -> int:
 	var damage := calculate_outgoing_damage(BASE_ATTACK)

--- a/src/enemies/SkeletonArcher.gd
+++ b/src/enemies/SkeletonArcher.gd
@@ -8,9 +8,11 @@ const VULNERABLE_STACKS: int = 2
 func _init() -> void:
 	super._init("Skeleton Archer", 18)
 	intent = Intent.DEBUFF
+	intent_value = BASE_ATTACK
 
 func decide_intent() -> void:
 	intent = Intent.DEBUFF
+	intent_value = BASE_ATTACK  # also deals damage after applying Vulnerable
 
 ## Shoots an arrow that deals damage and applies Vulnerable
 func execute_action(player: Player) -> int:

--- a/src/enemies/UndeadKnight.gd
+++ b/src/enemies/UndeadKnight.gd
@@ -13,6 +13,7 @@ var _attack_turn: int = 0  # 0 = Shield Bash, 1 = Bone Shatter, cycles
 func _init() -> void:
 	super._init("Undead Knight", BASE_HP)
 	intent = Intent.ATTACK
+	intent_value = SHIELD_BASH_DAMAGE  # first attack is always Shield Bash
 
 ## Override take_damage to intercept first death and Reanimate
 func take_damage(amount: int) -> int:
@@ -30,9 +31,11 @@ func _reanimate() -> void:
 ## Decide next intent (cycles Shield Bash → Bone Shatter → Shield Bash …)
 func decide_intent() -> void:
 	if _attack_turn % 2 == 0:
-		intent = Intent.ATTACK    # Shield Bash
+		intent = Intent.ATTACK        # Shield Bash
+		intent_value = SHIELD_BASH_DAMAGE
 	else:
-		intent = Intent.ATTACK    # Bone Shatter (also an attack, different method)
+		intent = Intent.ATTACK        # Bone Shatter (armor-piercing)
+		intent_value = BONE_SHATTER_DAMAGE
 
 ## Execute the turn action. Returns total HP damage dealt to player.
 func execute_action(player: Player) -> int:


### PR DESCRIPTION
Closes #17

Intent label now shows damage: **Attack (8)** instead of **Attack**.

- Added `intent_value: int` to Enemy base class
- All enemies set it in `_init()` and `decide_intent()`
- UndeadKnight cycles: Shield Bash = 10, Bone Shatter = 14
- GiantRat: 10 (2×5 total)
- CombatScene `_intent_label()` updated to take full Enemy ref and format with value